### PR TITLE
Relax kubeVersion check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ For releases `< 1.0.0` minor version step indicate breaking changes.
 
 ## [Unreleased] - YYYY-MM-DD
 
+### Changed
+
+- Relax `kubeVersion` of chart for better compatibility with custom/pre-release Kubernetes versions
+
 ## [sddi-ckan-1.2.1] - 2023-08-21
 
 ### Fixed

--- a/charts/sddi-ckan/Chart.yaml
+++ b/charts/sddi-ckan/Chart.yaml
@@ -12,7 +12,7 @@ sources:
 
 version: 1.2.1
 appVersion: "1.2.0"
-kubeVersion: ">= 1.23.0"
+kubeVersion: ">= 1.23.0-0"
 
 maintainers:
   - email: b.willenborg@tum.de

--- a/charts/sddi-ckan/README.md
+++ b/charts/sddi-ckan/README.md
@@ -20,7 +20,7 @@ Helm Chart for a SDDI enabled CKAN catalog. See [CHANGELOG](https://github.com/t
 
 ## Requirements
 
-Kubernetes: `>= 1.23.0`
+Kubernetes: `>= 1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|


### PR DESCRIPTION
@lreneral This should fix your issue with having to remove `kubeVersion` from the Chart. I tested it successfully in your cluster. This should avoid having to clone the entire deploy and allow you to use the official Helm repo.