### PR TITLE
Remove rather specific default for podSecurityContext for solr

### DIFF
--- a/charts/sddi-ckan/charts/solr/README.md
+++ b/charts/sddi-ckan/charts/solr/README.md
@@ -38,7 +38,7 @@ A Helm chart for Solr pre-configured for CKAN  and ckanext-spatial.
 | persistence.capacity | string | `"4Gi"` | Storage [capacity](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#capacity) |
 | persistence.storageClassName | string | `nil` | StorageClass to use, leave empty to use default StorageClass. |
 | podAnnotations | object | `{}` | Additional pod annotations |
-| podSecurityContext | object | `{"fsGroup":8983,"runAsGroup":8983,"runAsUser":8983}` | [k8s: Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
+| podSecurityContext | object | `{}` | [k8s: Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | resources.limits.cpu | string | `"2000m"` | [k8s: Resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | resources.limits.memory | string | `"8Gi"` | [k8s: Resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | resources.requests.cpu | string | `"500m"` | [k8s: Resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |

--- a/charts/sddi-ckan/charts/solr/values.yaml
+++ b/charts/sddi-ckan/charts/solr/values.yaml
@@ -33,10 +33,10 @@ serviceAccount:
   name: ""
 
 # -- [k8s: Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-podSecurityContext:
-  runAsUser: 8983
-  runAsGroup: 8983
-  fsGroup: 8983
+podSecurityContext: {}
+  # runAsUser: 8983
+  # runAsGroup: 8983
+  # fsGroup: 8983
 
 # -- [k8s: Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 securityContext: {}


### PR DESCRIPTION
Currently the solr chart has quite a specific default value for `podSecurityContext`:

```
podSecurityContext:
  runAsUser: 8983
  runAsGroup: 8983
  fsGroup: 8983
```

This makes it quite cumbersome to run the chart on OpenShift, which prohibits these UIDs. Furthermore it is currently not possible to override those defaults due to various bugs in Helm itself (e.g. see https://github.com/helm/helm/pull/12162).

This PR therefore changes the default value to `{}`.
