### PR TITLE
Remove rather specific default for podSecurityContext for solr and images configurable

### DIFF
--- a/charts/sddi-ckan/charts/ckan/templates/ckan-depl.yml
+++ b/charts/sddi-ckan/charts/ckan/templates/ckan-depl.yml
@@ -47,7 +47,7 @@ spec:
 
       initContainers:
       - name: init-data
-        image: busybox
+        image: "{{ .Values.initContainers.initdata.image.repository }}:{{ .Values.initContainers.initdata.image.tag }}"
         command: ["sh", "-c", "chown -Rv 92:92 {{ .Values.persistence.storagePath }}"]
         # securityContext:
         #   runAsUser: 0
@@ -59,7 +59,7 @@ spec:
           readOnly: false
 
       - name: pg-ready
-        image: bwibo/k8s-init-container
+        image: "{{ .Values.initContainers.pgready.image.repository }}:{{ .Values.initContainers.pgready.image.tag }}"
         command:
           - pg_isready
         env:

--- a/charts/sddi-ckan/charts/ckan/templates/ckan-statefulset.yml
+++ b/charts/sddi-ckan/charts/ckan/templates/ckan-statefulset.yml
@@ -47,7 +47,7 @@ spec:
 
       initContainers:
       - name: init-data
-        image: busybox
+        image: "{{ .Values.initContainers.initdata.image.repository }}:{{ .Values.initContainers.initdata.image.tag }}"
         command: ["sh", "-c", "chown -Rv 92:92 {{ .Values.persistence.storagePath }}"]
         volumeMounts:
         - name: data
@@ -55,7 +55,7 @@ spec:
           readOnly: false
 
       - name: pg-ready
-        image: bwibo/k8s-init-container
+        image: "{{ .Values.initContainers.pgready.image.repository }}:{{ .Values.initContainers.pgready.image.tag }}"
         command:
           - pg_isready
         env:

--- a/charts/sddi-ckan/charts/ckan/values.yaml
+++ b/charts/sddi-ckan/charts/ckan/values.yaml
@@ -21,6 +21,16 @@ image:
 # -- [Image pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
 imagePullSecrets: []
 
+initContainers:
+  initdata:
+    image:
+      repository: busybox
+      tag: latest
+  pgready:
+    image:
+      repository: bwibo/k8s-init-container
+      tag: latest
+
 # -- Additional pod annotations
 podAnnotations: {}
 

--- a/charts/sddi-ckan/charts/datapusher/templates/datapusher-depl.yml
+++ b/charts/sddi-ckan/charts/datapusher/templates/datapusher-depl.yml
@@ -44,7 +44,7 @@ spec:
       {{- if .Values.global.datapusher.db.enabled | default .Values.db.enabled }}
       initContainers:
       - name: pg-ready
-        image: bwibo/k8s-init-container
+        image: "{{ .Values.initContainers.pgready.image.repository }}:{{ .Values.initContainers.pgready.image.tag }}"
         command:
           - pg_isready
         env:

--- a/charts/sddi-ckan/charts/datapusher/values.yaml
+++ b/charts/sddi-ckan/charts/datapusher/values.yaml
@@ -20,6 +20,12 @@ image:
 # -- [Image pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
 imagePullSecrets: []
 
+initContainers:
+  pgready:
+    image:
+      repository: bwibo/k8s-init-container
+      tag: latest
+
 # -- Additional pod annotations
 podAnnotations: {}
 

--- a/charts/sddi-ckan/charts/solr/README.md
+++ b/charts/sddi-ckan/charts/solr/README.md
@@ -38,7 +38,7 @@ A Helm chart for Solr pre-configured for CKAN  and ckanext-spatial.
 | persistence.capacity | string | `"4Gi"` | Storage [capacity](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#capacity) |
 | persistence.storageClassName | string | `nil` | StorageClass to use, leave empty to use default StorageClass. |
 | podAnnotations | object | `{}` | Additional pod annotations |
-| podSecurityContext | object | `{"fsGroup":8983,"runAsGroup":8983,"runAsUser":8983}` | [k8s: Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
+| podSecurityContext | object | `{}` | [k8s: Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | resources.limits.cpu | string | `"2000m"` | [k8s: Resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | resources.limits.memory | string | `"8Gi"` | [k8s: Resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | resources.requests.cpu | string | `"500m"` | [k8s: Resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |

--- a/charts/sddi-ckan/charts/solr/values.yaml
+++ b/charts/sddi-ckan/charts/solr/values.yaml
@@ -33,10 +33,10 @@ serviceAccount:
   name: ""
 
 # -- [k8s: Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-podSecurityContext:
-  runAsUser: 8983
-  runAsGroup: 8983
-  fsGroup: 8983
+podSecurityContext: {}
+  # runAsUser: 8983
+  # runAsGroup: 8983
+  # fsGroup: 8983
 
 # -- [k8s: Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 securityContext: {}


### PR DESCRIPTION
Make some dockerhub images (repositories and tags) configurable.

We are using an internal [dockerhub pull through cache](https://docs.docker.com/registry/recipes/mirror/) to avoid reaching our [download-rate-limit](https://docs.docker.com/docker-hub/download-rate-limit/)

With this PR we can configure our own dockerhub pull through cache.