### PR TITLE
Openshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ To get this up an running in seconds, check out the [examples](examples). You wi
     [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/),
     usually a default for managed Kubernetes clusters.
 
+- Openshift `>= 4.13`
+
 ## :page_with_curl: Documentation
 
 The chart is documented in the chart directory: [charts/sddi-ckan](charts/sddi-ckan)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To get this up an running in seconds, check out the [examples](examples). You wi
     [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/),
     usually a default for managed Kubernetes clusters.
 
-- Openshift `>= 4.13`
+- [Openshift](#openshift) `>= 4.13`
 
 ## :page_with_curl: Documentation
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To get this up an running in seconds, check out the [examples](examples). You wi
     [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/),
     usually a default for managed Kubernetes clusters.
 
-- [Openshift](#openshift) `>= 4.13`
+- Openshift `>= 4.13`
 
 ## :page_with_curl: Documentation
 

--- a/charts/sddi-ckan/charts/ckan/templates/ckan-statefulset.yml
+++ b/charts/sddi-ckan/charts/ckan/templates/ckan-statefulset.yml
@@ -46,6 +46,7 @@ spec:
             claimName: {{ include "ckan.fullname" . }}
 
       initContainers:
+      {{ if .Values.initContainers.initdata.enabled }}
       - name: init-data
         image: "{{ .Values.initContainers.initdata.image.repository }}:{{ .Values.initContainers.initdata.image.tag }}"
         command: ["sh", "-c", "chown -Rv 92:92 {{ .Values.persistence.storagePath }}"]
@@ -53,6 +54,7 @@ spec:
         - name: data
           mountPath: {{ .Values.persistence.storagePath }}
           readOnly: false
+      {{ end }}
 
       - name: pg-ready
         image: "{{ .Values.initContainers.pgready.image.repository }}:{{ .Values.initContainers.pgready.image.tag }}"

--- a/charts/sddi-ckan/charts/ckan/templates/ckan-statefulset.yml
+++ b/charts/sddi-ckan/charts/ckan/templates/ckan-statefulset.yml
@@ -44,6 +44,15 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "ckan.fullname" . }}
+        - name: production-ini
+          emptyDir:
+            sizeLimit: 500Mi
+        - name: srv-app-i18n
+          emptyDir:
+            sizeLimit: 500Mi
+        - name: srv-app-data
+          emptyDir:
+            sizeLimit: 500Mi
 
       initContainers:
       {{ if .Values.initContainers.initdata.enabled }}
@@ -55,6 +64,19 @@ spec:
           mountPath: {{ .Values.persistence.storagePath }}
           readOnly: false
       {{ end }}
+
+      ## get original /srv/app/production.ini from image
+      # and copy to /tmp/
+      # to mount it in a writable emtpty dir
+      - name: copy-productionini
+        ## same image as container {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        command: ["/bin/sh","-c"]
+        args: ["cp -v /srv/app/production.ini /tmp/production.ini"]
+        volumeMounts:
+        - name: production-ini
+          mountPath: /tmp
+
 
       - name: pg-ready
         image: "{{ .Values.initContainers.pgready.image.repository }}:{{ .Values.initContainers.pgready.image.tag }}"
@@ -105,6 +127,13 @@ spec:
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.storagePath }}
+            - name: production-ini
+              mountPath: /srv/app/production.ini
+              subPath: production.ini
+            - name: srv-app-data
+              mountPath: /srv/app/data/
+            - name: srv-app-i18n
+              mountPath: /srv/app/src/ckan/ckan/public/base/i18n/
 
           startupProbe:
             httpGet:

--- a/charts/sddi-ckan/charts/ckan/values.yaml
+++ b/charts/sddi-ckan/charts/ckan/values.yaml
@@ -23,6 +23,7 @@ imagePullSecrets: []
 
 initContainers:
   initdata:
+    enabled: true
     image:
       repository: busybox
       tag: latest


### PR DESCRIPTION
Changes required for Openshift
What we need for a working Openshift are (currently) three things:

*  __disable__ initContainer __`init-data`__, UID 92 is not working in Openshift, we need arbitrary UID < 1001
* make the directories `/srv/app/data/` and `/srv/app/src/ckan/ckan/public/base/i18n/` writable, in Openshift all files from the image are immutable.
* get the existing and not empty file `/srv/app/production.ini` also writable.





