### PR TITLE
High availability for Redis, Solr and Postgres

### DIFF
--- a/charts/sddi-ckan/charts/redis/templates/redis-statefulset.yml
+++ b/charts/sddi-ckan/charts/redis/templates/redis-statefulset.yml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.component }}
 spec:
   serviceName: {{ include "redis.fullname" . }}-hl
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "redis.selectorLabels" . | nindent 6 }}

--- a/charts/sddi-ckan/charts/redis/values.yaml
+++ b/charts/sddi-ckan/charts/redis/values.yaml
@@ -68,6 +68,8 @@ persistence:
     # helm.sh/resource-policy: keep
 
 # -- Number of replicas. Only used if `autoscaling.enabled = false`.
+# **Note:** Running multiple replicas requires to enable persistent data storage (`persistence.enabled = true`) and,
+# if Pods run on different nodes, a storage that supports RWX.
 replicaCount: 1
 autoscaling:
   # -- Enable/disable pod autoscaling, if disabled `replicaCount` is used to set number of pods.

--- a/charts/sddi-ckan/charts/solr/templates/solr-statefulset.yml
+++ b/charts/sddi-ckan/charts/solr/templates/solr-statefulset.yml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/component: {{ .Values.component }}
 spec:
   serviceName: {{ include "solr.fullname" . }}-hl
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "solr.selectorLabels" . | nindent 6 }}

--- a/charts/sddi-ckan/charts/solr/values.yaml
+++ b/charts/sddi-ckan/charts/solr/values.yaml
@@ -67,6 +67,11 @@ persistence:
   annotations:
   # helm.sh/resource-policy: keep
 
+# -- Number of replicas.
+# **Note:** Running multiple replicas requires to enable persistent data storage (`persistence.enabled = true`) and,
+# if Pods run on different nodes, a storage that supports RWX.
+replicaCount: 1
+
 # initContainers --------------------------------------------------------------
 # -- Sets [`initContainers`](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/).
 # Set to `[]` to disable the default initContainers.


### PR DESCRIPTION
Proposed changes:

- Make number of replicas configurable for Solr statefulset 
- Make number of replicas configurable for Redis statefulset

Background: We recently had an OpenShift update which produced some Solr Errors. Not a big thing, but as solr needs circa 1 minute for startup, the possibility of scaling up the number of pods/ containers would be good for high availability.

I added Redis for completeness. I see no reason why Redis replica count is only used for deployment and not for statefulset, but please do not hesitate to correct me here.

@BWibo I addressed the branch release/3.0.0 because we use it at the moment. No problem to change this to the main branch if it's more convenient for you.
