### PR TITLE
Ingress configuration snippet headers

### DIFF
--- a/charts/sddi-ckan/charts/ckan/templates/ckan-ingress.yml
+++ b/charts/sddi-ckan/charts/ckan/templates/ckan-ingress.yml
@@ -30,10 +30,7 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.maxUploadSizeMB }}m"
     nginx.org/client-max-body-size: "{{ .Values.maxUploadSizeMB }}m"
-    {{- range .Values.ingress.configurationSnippet }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{ . | quote }}
-    {{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: {{- .Values.ingress.configurationSnippet | toYaml | indent 4 }}
     {{- if .Values.ingress.stickySessions.enabled }}
     # https://kubernetes.github.io/ingress-nginx/examples/affinity/cookie/
     nginx.ingress.kubernetes.io/affinity: "cookie"

--- a/charts/sddi-ckan/charts/ckan/templates/ckan-ingress.yml
+++ b/charts/sddi-ckan/charts/ckan/templates/ckan-ingress.yml
@@ -30,6 +30,10 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.maxUploadSizeMB }}m"
     nginx.org/client-max-body-size: "{{ .Values.maxUploadSizeMB }}m"
+    {{- range .Values.ingress.configurationSnippet }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {{ . | quote }}
+    {{- end }}
     {{- if .Values.ingress.stickySessions.enabled }}
     # https://kubernetes.github.io/ingress-nginx/examples/affinity/cookie/
     nginx.ingress.kubernetes.io/affinity: "cookie"

--- a/charts/sddi-ckan/charts/ckan/values.yaml
+++ b/charts/sddi-ckan/charts/ckan/values.yaml
@@ -132,9 +132,11 @@ ingress:
   tls:
     # -- Specify a custom tls secret name. This overwrites `global.ingress.tls.secretName`.
     secretName:
-  configurationSnippet:
-    - more_set_headers "X-Frame-Options: Deny";
-    - more_set_headers "X-XSS-Protection: 1; mode=block";
+  configurationSnippet: |
+    more_set_headers "X-Frame-Options: DENY";
+    more_set_headers "X-Xss-Protection: 0";
+    more_set_headers "X-Content-Type-Options: nosniff";
+    more_set_headers "Content-Security-Policy: default-src 'self'; object-src 'none'; child-src 'self'; frame-ancestors 'none'; base-uri 'none'; upgrade-insecurerequests; blockall-mixed-content; require-trustedtypes-for 'script'";
 
 # General settings
 # -- CKAN site url. This should match a domain name of CKAN specified in `ingress.domains`/`global.ingress.domains`

--- a/charts/sddi-ckan/charts/ckan/values.yaml
+++ b/charts/sddi-ckan/charts/ckan/values.yaml
@@ -136,7 +136,7 @@ ingress:
     more_set_headers "X-Frame-Options: DENY";
     more_set_headers "X-Xss-Protection: 0";
     more_set_headers "X-Content-Type-Options: nosniff";
-    more_set_headers "Content-Security-Policy: default-src 'self'; object-src 'none'; child-src 'self'; frame-ancestors 'none'; base-uri 'none'; upgrade-insecurerequests; blockall-mixed-content; require-trustedtypes-for 'script'";
+    more_set_headers "Content-Security-Policy: object-src 'none'; child-src 'self'; frame-ancestors 'none'; base-uri 'none'; upgrade-insecurerequests; blockall-mixed-content; require-trustedtypes-for 'script'";
 
 # General settings
 # -- CKAN site url. This should match a domain name of CKAN specified in `ingress.domains`/`global.ingress.domains`

--- a/charts/sddi-ckan/charts/ckan/values.yaml
+++ b/charts/sddi-ckan/charts/ckan/values.yaml
@@ -132,6 +132,9 @@ ingress:
   tls:
     # -- Specify a custom tls secret name. This overwrites `global.ingress.tls.secretName`.
     secretName:
+  configurationSnippet:
+    - more_set_headers "X-Frame-Options: Deny";
+    - more_set_headers "X-XSS-Protection: 1; mode=block";
 
 # General settings
 # -- CKAN site url. This should match a domain name of CKAN specified in `ingress.domains`/`global.ingress.domains`


### PR DESCRIPTION
The Ingress configuration snippet depends on `allow-snippet-annotations: "false"` which is part of the Ingress Controller ConfigMap.