### PR TITLE
add edited clamav chart with podSecurityContext: {}

### DIFF
--- a/charts/sddi-ckan/Chart.yaml
+++ b/charts/sddi-ckan/Chart.yaml
@@ -51,7 +51,6 @@ dependencies:
   - name: clamav
     condition: clamav.enabled
     version: "~2.8.0"
-    repository: https://wiremind.github.io/wiremind-helm-charts
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:

--- a/charts/sddi-ckan/charts/clamav/.helmignore
+++ b/charts/sddi-ckan/charts/clamav/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/sddi-ckan/charts/clamav/Chart.yaml
+++ b/charts/sddi-ckan/charts/clamav/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+appVersion: 1.9.50
+description: An Open-Source antivirus engine for detecting trojans, viruses, malware
+  & other malicious threats. Using Mailu docker image.
+home: https://www.clamav.net
+icon: https://www.clamav.net/assets/clamav-trademark.png
+maintainers:
+- name: Wiremind
+  url: https://github.com/wiremind/wiremind-helm-charts
+name: clamav
+sources:
+- https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/clamav
+- https://github.com/Mailu/Mailu/tree/master/optional/clamav
+- https://hub.docker.com/r/mailu/clamav
+- https://github.com/Cisco-Talos/clamav-devel
+version: 2.8.3

--- a/charts/sddi-ckan/charts/clamav/README.md
+++ b/charts/sddi-ckan/charts/clamav/README.md
@@ -1,0 +1,64 @@
+# ClamAV
+
+##  An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
+
+[ClamAV](https://www.clamav.net/) is the open source standard for mail gateway scanning software.
+ Developed by [Cisco Talos](https://github.com/Cisco-Talos/clamav-devel). This Helm Chart uses the [MailU](https://github.com/Mailu/Mailu) Docker image. `appVersion` shows the Mailu/clamav container image version.
+
+## QuickStart
+
+```bash
+$ helm repo add wiremind https://wiremind.github.io/wiremind-helm-charts
+$ helm install my-release wiremind/clamav
+```
+
+## Introduction
+
+This chart bootstraps a ClamAV deployment and service on a Kubernetes cluster using the Helm Package manager.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm repo add wiremind https://wiremind.github.io/wiremind-helm-charts
+$ helm install my-release wiremind/clamav
+```
+
+The command deploys ClamAV on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The configurable parameters of the ClamAV chart and
+their descriptions can be seen in `values.yaml`. The [full documentation](https://www.clamav.net/documents/clam-antivirus-0-101-0-user-manual) contains more information about running ClamAV in docker.
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Memory Usage
+
+ClamAV uses around 1 GB RAM.
+
+# Virus Definitions
+
+For ClamAV to work properly, both the ClamAV engine and the ClamAV Virus Database (CVD) must be kept up to date.
+
+The virus database is usually updated many times per week.
+
+Freshclam should perform these updates automatically. Instructions for setting up Freshclam can be found in the [documentation](https://www.clamav.net/documents/clam-antivirus-0-101-0-user-manual) section.
+If your network is segmented or the end hosts are unable to reach the Internet, you should investigate setting up a private local mirror. If this is not viable, you may use these direct [download](https://www.clamav.net/downloads)

--- a/charts/sddi-ckan/charts/clamav/ci/default-values.yaml
+++ b/charts/sddi-ckan/charts/clamav/ci/default-values.yaml
@@ -1,0 +1,1 @@
+fullnameOverride: clamav

--- a/charts/sddi-ckan/charts/clamav/ci/hpa-values.yaml
+++ b/charts/sddi-ckan/charts/clamav/ci/hpa-values.yaml
@@ -1,0 +1,2 @@
+hpa:
+  memory: 80

--- a/charts/sddi-ckan/charts/clamav/templates/NOTES.txt
+++ b/charts/sddi-ckan/charts/clamav/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. To connect to your ClamAV instance from outside the cluster execute the following commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "clamav.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo $NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "clamav.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "clamav.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo $SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "clamav.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo 127.0.0.1:3310
+  kubectl port-forward $POD_NAME 3310:3310
+{{- end }}

--- a/charts/sddi-ckan/charts/clamav/templates/_helpers.tpl
+++ b/charts/sddi-ckan/charts/clamav/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "clamav.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "clamav.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "clamav.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "clamav.labels" -}}
+app.kubernetes.io/name: {{ include "clamav.name" . }}
+helm.sh/chart: {{ include "clamav.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "clamav.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clamav.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ Create the name of the service account to use
+ */}}
+{{- define "clamav.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "clamav.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+

--- a/charts/sddi-ckan/charts/clamav/templates/clamd-configmap.yaml
+++ b/charts/sddi-ckan/charts/clamav/templates/clamd-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.clamdConfig -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "clamav.fullname" . }}-clamd
+  labels:
+    app: {{ template "clamav.name" . }}
+    chart: {{ template "clamav.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  clamd.conf:
+    {{ toYaml .Values.clamdConfig | indent 4 }}
+{{- end }}

--- a/charts/sddi-ckan/charts/clamav/templates/freshclam-configmap.yaml
+++ b/charts/sddi-ckan/charts/clamav/templates/freshclam-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.freshclamConfig -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "clamav.fullname" . }}-freshclam
+  labels:
+    app: {{ template "clamav.name" . }}
+    chart: {{ template "clamav.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  freshclam.conf:
+    {{ toYaml .Values.freshclamConfig | indent 4 }}
+{{- end }}

--- a/charts/sddi-ckan/charts/clamav/templates/hpa.yaml
+++ b/charts/sddi-ckan/charts/clamav/templates/hpa.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.hpa.enabled -}}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
+apiVersion: autoscaling/v2beta2
+{{- end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "clamav.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ template "clamav.fullname" . }}
+  minReplicas: {{ .Values.replicaCount }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  {{- if .Values.hpa.cpu }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.cpu }}
+  {{- end }}
+  {{- if .Values.hpa.memory }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.memory }}
+  {{- end }}
+  {{- if .Values.hpa.requests }}
+  - type: Pods
+    pods:
+      metric:
+        name: http_requests
+      target:
+        type: AverageValue
+        averageValue: {{ .Values.hpa.requests }}
+  {{- end }}
+{{- end }}

--- a/charts/sddi-ckan/charts/clamav/templates/ingress.yaml
+++ b/charts/sddi-ckan/charts/clamav/templates/ingress.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "clamav.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "clamav.name" . }}
+    helm.sh/chart: {{ include "clamav.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+        - backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: clamavport
+          path: {{ $ingressPath }}
+          pathType: Prefix
+  {{- end -}}
+{{- end }}

--- a/charts/sddi-ckan/charts/clamav/templates/poddisruptionbudget.yaml
+++ b/charts/sddi-ckan/charts/clamav/templates/poddisruptionbudget.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "clamav.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "clamav.name" . }}
+    helm.sh/chart: {{ include "clamav.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "clamav.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/sddi-ckan/charts/clamav/templates/service.yaml
+++ b/charts/sddi-ckan/charts/clamav/templates/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clamav.fullname" . }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "clamav.name" . }}
+    helm.sh/chart: {{ include "clamav.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: clamavport
+      protocol: TCP
+      name: clamavport
+    {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "clamav.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/sddi-ckan/charts/clamav/templates/serviceaccount.yaml
+++ b/charts/sddi-ckan/charts/clamav/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clamav.serviceAccountName" . }}
+  labels:
+    {{- include "clamav.labels" . | nindent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
+

--- a/charts/sddi-ckan/charts/clamav/templates/statefulset.yaml
+++ b/charts/sddi-ckan/charts/clamav/templates/statefulset.yaml
@@ -1,0 +1,139 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "clamav.fullname" . }}
+  labels:
+    {{- include "clamav.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "clamav.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "clamav.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.podAnnotations }}
+        {{ toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "clamav.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{ toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "clamav.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+          {{- if .Values.freshclamConfig }}
+          - name: freshclam-config-volume
+            mountPath: /etc/clamav/freshclam.conf
+            subPath: freshclam.conf
+          {{- end }}
+          {{- if .Values.clamdConfig }}
+          - name: clamd-config-volume
+            mountPath: /etc/clamav/clamd.conf
+            subPath: clamd.conf
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 10 }}
+          {{- end }}
+          - name: clamav-data
+            mountPath: /data
+          ports:
+            - name: clamavport
+              containerPort: 3310
+              protocol: TCP
+          startupProbe:
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            tcpSocket:
+              port: clamavport
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            tcpSocket:
+              port: clamavport
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            tcpSocket:
+              port: clamavport
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if .Values.freshclamConfig }}
+        - name: freshclam-config-volume
+          configMap:
+            name: {{ include "clamav.fullname" . }}-freshclam
+        {{- end }}
+        {{- if .Values.clamdConfig }}
+        - name: clamd-config-volume
+          configMap:
+            name: {{ include "clamav.fullname" . }}-clamd
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
+  {{- if not .Values.persistentVolume.enabled }}
+        - name: clamav-data
+          emptyDir: {}
+  {{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: clamav-data
+        labels:
+          {{- include "clamav.labels" . | nindent 10 }}
+        {{- if .Values.persistentVolume.annotations }}
+        annotations:
+          {{- .Values.persistentVolume.annotations | toYaml | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.persistentVolume.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        {{- if .Values.persistentVolume.storageClass }}
+        {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+        {{- end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistentVolume.size | quote }}
+  {{- end }}

--- a/charts/sddi-ckan/charts/clamav/values.schema.json
+++ b/charts/sddi-ckan/charts/clamav/values.schema.json
@@ -1,0 +1,303 @@
+
+
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository",
+        "tag",
+        "pullPolicy"
+      ]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {}
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "nodePort": {
+          "type": "integer"
+        },
+        "annotations": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "type",
+        "port",
+        "annotations"
+      ]
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "path": {
+          "type": "string"
+        },
+        "hosts": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "tls": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "secretName": {
+                  "type": "string"
+                },
+                "hosts": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "secretName",
+                "hosts"
+              ]
+            }
+          ]
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "clamdConfig": {
+      "type": ["string"]
+    },
+    "freshclamConfig": {
+      "type": ["string"]
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        },
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {}
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        },
+        "failureThreshold": {
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "initialDelaySeconds",
+        "periodSeconds",
+        "failureThreshold",
+        "timeoutSeconds"
+      ]
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        },
+        "failureThreshold": {
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "initialDelaySeconds",
+        "periodSeconds",
+        "failureThreshold",
+        "timeoutSeconds"
+      ]
+    },
+    "hpa": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "maxReplicas": {
+          "type": "integer"
+        },
+        "cpu": {
+          "type": "integer"
+        },
+        "memory": {
+          "type": "integer"
+        },
+        "requests": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "type": "integer"
+        },
+        "maxUnavailable": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {}
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {}
+    },
+    "persistentVolume": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "size": {
+          "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    }
+  },
+  "required": [
+    "replicaCount",
+    "image",
+    "imagePullSecrets",
+    "nameOverride",
+    "fullnameOverride",
+    "service",
+    "ingress",
+    "clamdConfig",
+    "freshclamConfig",
+    "resources",
+    "podLabels",
+    "nodeSelector",
+    "tolerations",
+    "affinity",
+    "livenessProbe",
+    "readinessProbe",
+    "hpa",
+    "podDisruptionBudget",
+    "extraVolumes",
+    "extraVolumeMounts",
+    "persistentVolume"
+  ]
+}

--- a/charts/sddi-ckan/charts/clamav/values.yaml
+++ b/charts/sddi-ckan/charts/clamav/values.yaml
@@ -1,0 +1,258 @@
+# Default values for ClamAV.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  # TODO: Switch to clamav/clamav container
+  repository: ghcr.io/mailu/clamav
+  tag: ""  # If not defined, uses appVersion
+  pullPolicy: IfNotPresent
+
+priorityClassName: ""
+
+## Optionally specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+##
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Temporary workaround because of helm being unable to take {} or null values in subcharts,
+# see https://github.com/helm/helm/pull/12879
+#podSecurityContext:
+#  runAsNonRoot: true
+#  runAsUser: 2000
+#  runAsGroup: 2000
+podSecurityContext: {}
+
+
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  privileged: false
+  capabilities:
+    drop:
+      - ALL
+
+serviceAccount:
+  create: true
+  name: ""
+  automountServiceAccountToken: false
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 3310
+  # nodePort: 30100
+  annotations: {}
+
+ingress:
+  enabled: false
+# ingressClassName: ""
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## Ref: https://linux.die.net/man/5/clamd.conf
+## Note: will completely override default clamd.conf file at https://github.com/Mailu/Mailu/tree/master/optional/clamav/conf
+clamdConfig: |
+  ###############
+  # General
+  ###############
+
+  DatabaseDirectory /data
+  TemporaryDirectory /tmp
+  LogTime yes
+  # CUSTOM: Use pid file in tmp
+  PidFile /tmp/clamd.pid
+  LocalSocket /tmp/clamd.sock
+  # CUSTOM: Set local socket group to defined group id
+  LocalSocketGroup 2000
+  TCPSocket 3310
+  Foreground yes
+
+  ###############
+  # Results
+  ###############
+
+  DetectPUA yes
+  ExcludePUA NetTool
+  ExcludePUA PWTool
+  HeuristicAlerts yes
+  Bytecode yes
+
+  ###############
+  # Scan
+  ###############
+
+  ScanPE yes
+  DisableCertCheck yes
+  ScanELF yes
+  AlertBrokenExecutables yes
+  ScanOLE2 yes
+  ScanPDF yes
+  ScanSWF yes
+  ScanMail yes
+  PhishingSignatures yes
+  PhishingScanURLs yes
+  ScanHTML yes
+  ScanArchive yes
+
+  ###############
+  # Scan
+  ###############
+
+  MaxScanSize 150M
+  MaxFileSize 30M
+  MaxRecursion 10
+  MaxFiles 15000
+  MaxEmbeddedPE 10M
+  MaxHTMLNormalize 10M
+  MaxHTMLNoTags 2M
+  MaxScriptNormalize 5M
+  MaxZipTypeRcg 1M
+  MaxPartitions 128
+  MaxIconsPE 200
+  PCREMatchLimit 10000
+  PCRERecMatchLimit 10000
+
+## Ref: https://linux.die.net/man/5/freshclam.conf
+## Note: will completely override default clamd.conf file at https://github.com/Mailu/Mailu/tree/master/optional/clamav/conf
+freshclamConfig: |
+  ###############
+  # General
+  ###############
+
+  DatabaseDirectory /data
+  UpdateLogFile /dev/stdout
+  LogTime yes
+  # CUSTOM: Use pid file in tmp
+  PidFile /tmp/freshclam.pid
+  # CUSTOM: Set defined user
+  DatabaseOwner 2000
+
+  ###############
+  # Updates
+  ###############
+
+  DatabaseMirror database.clamav.net
+  ScriptedUpdates yes
+  NotifyClamd /etc/clamav/clamd.conf
+  Bytecode yes
+
+# Use freshclamConfig to define the content of /etc/clamav/freshclam.conf. Example:
+# freshclamConfig: |
+#   HTTPProxyServer your-proxy.example.com
+#   HTTPProxyPort 8080
+#   DatabaseDirectory /data
+#   LogSyslog yes
+#   LogTime yes
+#   PidFile /run/clamav/freshclam.pid
+#   DatabaseOwner root
+#   DatabaseMirror database.clamav.net
+#   ScriptedUpdates yes
+#   NotifyClamd /etc/clamav/clamd.conf
+#   SafeBrowsing yes
+#   Bytecode yes
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+# Additional pod labels
+podLabels: {}
+podAnnotations: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+startupProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 3
+  timeoutSeconds: 1
+
+livenessProbe:
+  initialDelaySeconds: 300
+  periodSeconds: 10
+  failureThreshold: 3
+  timeoutSeconds: 1
+
+readinessProbe:
+  initialDelaySeconds: 90
+  periodSeconds: 10
+  failureThreshold: 3
+  timeoutSeconds: 1
+
+hpa:
+  enabled: true
+  maxReplicas: 5
+  # average CPU usage utilization percentage per pod (1-100)
+  cpu: 80
+  # average Memory usage utilization percentage per pod (1-100)
+  # memory: 80
+  # average http_requests utilization per pod (value as a string)
+  # requests: 1k
+
+podDisruptionBudget:
+  enabled: false
+  # minAvailable: 1
+  # maxUnavailable: 1
+
+## extraVolumes Optionally specify extra list of additional volumes for the Clam Pod(s)
+##
+extraVolumes: []
+## extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Clam container(s)
+##
+extraVolumeMounts: []
+
+## Clamav data dir persistence
+persistentVolume:
+  ## If true, a Persistent Volume Claim is created, otherwise it uses an emptyDir
+  ##
+  enabled: false
+
+  ## Persistent Volume Claim annotations
+  ##
+  annotations: {}
+
+  ## Persistent Volume access modes
+  ## Must match those of existing PV or dynamic provisioner
+  ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  accessModes:
+  - ReadWriteOnce
+
+  ## Persistent Volume Size
+  ##
+  size: 100Mi
+
+  ## Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"


### PR DESCRIPTION
In the OpenShift environment at Landeshauptstadt München (LHM) we are restricted from using predefined users or groups. The  clamav subchart values for `PodSecurityContext` , `runAsUser`and `runAsGroup`  cannot be updated via values.yaml to `{}` or `Null` because of an unresolved [helm issue](https://github.com/helm/helm/pull/12879).

Our workaround is to add the edited clamav chart directly to the repo instead of pulling it from wiremind. The only changed value is `PodSecurityContext`: https://github.com/it-at-m/sddi-ckan-k8s/blob/46f8e82d4cdf712b2ab255774fb0dc5d5f74a88e/charts/sddi-ckan/charts/clamav/values.yaml#L30