### PR TITLE
Make solr volumes and volumeMounts configurable

### DIFF
--- a/charts/sddi-ckan/charts/solr/templates/solr-statefulset.yml
+++ b/charts/sddi-ckan/charts/solr/templates/solr-statefulset.yml
@@ -33,9 +33,9 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
 
       volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: {{ include "solr.fullname" . }}
+      {{- if .Values.volumes }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.volumes  "context" $ ) | nindent 8 }}
+      {{- end }}
 
       initContainers:
       {{- if .Values.initContainers }}
@@ -58,8 +58,9 @@ spec:
               protocol: TCP
 
           volumeMounts:
-            - name: data
-              mountPath: /var/solr/data
+          {{- if .Values.volumeMounts }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.volumeMounts  "context" $ ) | nindent 10 }}
+          {{- end }}
 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/sddi-ckan/charts/solr/values.yaml
+++ b/charts/sddi-ckan/charts/solr/values.yaml
@@ -86,6 +86,27 @@ initContainers:
 # The initContainers specified here, are appended to the ones specified in `initContainers`.
 extraInitContainers: []
 
+# Volumes ---------------------------------------------------------------------
+# -- Sets [`volumes`](https://kubernetes.io/docs/concepts/storage/volumes).
+# Set to `[]` to disable the default volumes.
+# Set to any list of volume definitions to overwrite the default volumes.
+# Use `extraVolumes` to extend the default volumes.
+# @default -- See [`values.yml`](values.yml) for the list of default volumes.
+volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: '{{ include "ckan.fullname" . }}'
+
+# VolumeMounts ----------------------------------------------------------------
+# -- Sets [`volumeMounts`](https://kubernetes.io/docs/concepts/storage/volumes).
+# Set to `[]` to disable the default volumeMounts.
+# Set to any list of volumeMount definitions to overwrite the default volumeMounts.
+# Use `extraVolumeMounts` to extend the default volumeMounts.
+# @default -- See [`values.yml`](values.yml) for the list of default volumeMounts.
+volumeMounts:
+  - name: data
+    mountPath: /var/solr/data
+
 # -- [k8s: Resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
 resources: {}
 # -- [k8s: Assign pods to nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)


### PR DESCRIPTION
We propose this change for having the opportunity to include a solr schema included in a ConfigMap. This is necessary because of the issue described in https://github.com/ckan/ckan-solr/issues/15 and to customize search settings.

The proposed workaround for the issue, using `ckan/ckan-solr:2.9-solr8` does not work for us.