### PR TITLE
update wiremind chart version

### DIFF
--- a/charts/sddi-ckan/Chart.yaml
+++ b/charts/sddi-ckan/Chart.yaml
@@ -50,7 +50,7 @@ dependencies:
     repository: https://charts.jetstack.io
   - name: clamav
     condition: clamav.enabled
-    version: "~2.8.0"
+    version: 3.5.0
     repository: https://wiremind.github.io/wiremind-helm-charts
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
Hi, is it possible to update the wiremind chart version? In LHM OpenShift, version 2.8.3 leads to permission errors.