### PR TITLE
fix(ckan): pass root context to ckan.fullname include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ For releases `< 1.0.0` minor version step indicate breaking changes.
 
 ## [Unreleased] - 2025-04-08
 
+## [sddi-ckan-4.2.2] - 2026-08-10
+
+### Fixed
+
+- Missing root context argument (`.`) in the `ckan.fullname` include call in `ckan-service.yaml`, tum-gis/sddi-ckan-k8s#55
+
 ## [sddi-ckan-4.2.1] - 2026-08-10
+
+**Broken - do not use** Contains a bug in the `ckan.fullname` include call (missing root context). Fixed in `4.2.2`.
 
 ### Changed
 
@@ -443,9 +451,9 @@ is displayed when navigating to the _Datasets_ view of CKAN.
 
 ### Known issues
 
-[Unreleased]: https://github.com/tum-gis/sddi-ckan-k8s/compare/sddi-ckan-4.2.1...HEAD
+[Unreleased]: https://github.com/tum-gis/sddi-ckan-k8s/compare/sddi-ckan-4.2.2...HEAD
 
-[sddi-ckan-4.2.1]: https://github.com/tum-gis/sddi-ckan-k8s/compare/sddi-ckan-4.2.0...sddi-ckan-4.2.1
+[sddi-ckan-4.2.2]: https://github.com/tum-gis/sddi-ckan-k8s/compare/sddi-ckan-4.2.1...sddi-ckan-4.2.2
 [sddi-ckan-4.2.0]: https://github.com/tum-gis/sddi-ckan-k8s/compare/sddi-ckan-4.1.0...sddi-ckan-4.2.0
 [sddi-ckan-4.1.0]: https://github.com/tum-gis/sddi-ckan-k8s/compare/sddi-ckan-4.0.0...sddi-ckan-4.1.0
 [sddi-ckan-4.0.0]: https://github.com/tum-gis/sddi-ckan-k8s/compare/sddi-ckan-3.0.0...sddi-ckan-4.0.0

--- a/charts/sddi-ckan/Chart.yaml
+++ b/charts/sddi-ckan/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://www.asg.ed.tum.de/en/gis/projects/smart-district-data-infrastructure
   - https://github.com/tum-gis/ckan-docker
 
-version: 4.2.1
+version: 4.2.2
 appVersion: "3.1.1"
 kubeVersion: ">= 1.23.0-0"
 

--- a/charts/sddi-ckan/charts/ckan/Chart.yaml
+++ b/charts/sddi-ckan/charts/ckan/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/tum-gis/ckan-docker
   - https://github.com/keitaroinc/docker-ckan
 
-version: 4.2.1
+version: 4.2.2
 appVersion: "3.1.1"
 
 maintainers:

--- a/charts/sddi-ckan/charts/ckan/templates/ckan-service.yml
+++ b/charts/sddi-ckan/charts/ckan/templates/ckan-service.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "ckan.fullname" }}
+  name: {{ include "ckan.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "ckan.labels" . | nindent 4 }}


### PR DESCRIPTION
## Description

Fixes a typo in `ckan-service.yaml` from the previous change (#55 ): the `include "ckan.fullname"` call was missing the `.` root context argument, which is required for the template function to resolve values correctly.

**Before:**
```yaml
name: {{ include "ckan.fullname"  }}
```

**After:**
```yaml
name: {{ include "ckan.fullname" . }}
```

## Testing

- Verified `helm template` renders the service name correctly